### PR TITLE
Update to use latest tag as latest version for git dependencies

### DIFF
--- a/src/Gemfile
+++ b/src/Gemfile
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-ruby "2.6.9"
+ruby "2.7.0"
 
 source "https://rubygems.org"
 
-gem "dependabot-omnibus", "~> 0.176.0"
+gem "dependabot-omnibus", "~> 0.180.5"


### PR DESCRIPTION
WIP hack to work around out-of-order tagging.

This could potentially be incorporated with the upstream by making this behavior configurable. 